### PR TITLE
fix: Update static volume naming in docker-compose to remove environm…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
 volumes:
   static-volume:
     external: false
-    name: ${PROJECT_NAME}-static-volume-${ENV}
+    name: ${PROJECT_NAME}-static-volume
   db-volume:
     external: false
     name: ${PROJECT_NAME}-db-volume-${ENV}


### PR DESCRIPTION
…ent variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - 静的アセット用ボリューム名を環境に依存しない固定名へ変更。環境間で同一名となるため、既存セットアップでは再作成や再マウントが発生する場合があります。必要に応じて古いボリュームの移行やクリーンアップをご確認ください。
  - データベース用ボリューム名は従来どおり環境サフィックス付きのまま。既存のデータベースボリューム運用に影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->